### PR TITLE
Implement "SortBy" parameter and improve "Strict" parameter behaviour.

### DIFF
--- a/MSCatalog/Classes/MSCatalogResponse.Class.ps1
+++ b/MSCatalog/Classes/MSCatalogResponse.Class.ps1
@@ -1,0 +1,18 @@
+class MSCatalogResponse {
+    [HtmlAgilityPack.HtmlNodeCollection] $Rows
+    [string] $EventArgument
+    [string] $EventValidation
+    [string] $ViewState
+    [string] $ViewStateGenerator
+    [string] $NextPage
+
+    MSCatalogResponse($HtmlDoc) {
+        $Table = $HtmlDoc.GetElementbyId("ctl00_catalogBody_updateMatches")
+        $this.Rows = $Table.SelectNodes("tr")
+        $this.EventArgument = $HtmlDoc.GetElementbyId("__EVENTARGUMENT")[0].Attributes["value"].Value
+        $this.EventValidation = $HtmlDoc.GetElementbyId("__EVENTVALIDATION")[0].Attributes["value"].Value
+        $this.ViewState = $HtmlDoc.GetElementbyId("__VIEWSTATE")[0].Attributes["value"].Value
+        $this.ViewStateGenerator = $HtmlDoc.GetElementbyId("__VIEWSTATEGENERATOR")[0].Attributes["value"].Value
+        $this.NextPage = $HtmlDoc.GetElementbyId("ctl00_catalogBody_nextPage")
+    }
+}

--- a/MSCatalog/Classes/MSCatalogUpdate.Class.ps1
+++ b/MSCatalog/Classes/MSCatalogUpdate.Class.ps1
@@ -1,0 +1,31 @@
+class MSCatalogUpdate {
+    [string] $Title
+    [string] $Products
+    [string] $Classification
+    [datetime] $LastUpdated
+    [string] $Version
+    [string] $Size
+    [string] $SizeInBytes 
+    [string] $Guid
+    [string[]] $FileNames
+
+    MSCatalogUpdate() {}
+
+    MSCatalogUpdate($Row, $IncludeFileNames) {
+        $Cells = $Row.SelectNodes("td")
+        $this.Title = $Cells[1].innerText.Trim()
+        $this.Products = $Cells[2].innerText.Trim()
+        $this.Classification = $Cells[3].innerText.Trim()
+        $this.LastUpdated = (Invoke-ParseDate -DateString $Cells[4].innerText.Trim())
+        $this.Version = $Cells[5].innerText.Trim()
+        $this.Size = $Cells[6].SelectNodes("span")[0].InnerText
+        $this.SizeInBytes = [Int] $Cells[6].SelectNodes("span")[1].InnerText 
+        $this.Guid = $Cells[7].SelectNodes("input")[0].Id
+        $this.FileNames = if ($IncludeFileNames) {
+            $Links = Get-UpdateLinks -Guid $Cells[7].SelectNodes("input")[0].Id
+            foreach ($Link in $Links.Matches) {
+                $Link.Value.Split('/')[-1]
+            }
+        }
+    }
+}

--- a/MSCatalog/MSCatalog.psm1
+++ b/MSCatalog/MSCatalog.psm1
@@ -1,18 +1,4 @@
-# Get public function definition files and dot source them
-$Public = @(Get-ChildItem -Path $PSScriptRoot\Public\*.ps1)
-$Private = @(Get-ChildItem -Path $PSScriptRoot\Private\*.ps1)
 
-foreach ($Module in ($Public + $Private)) {
-    try {
-        . $Module.FullName
-    } catch {
-        Write-Error -Message "Failed to import function $($Module.FullName): $_"
-    }
-}
-
-Export-ModuleMember -Function $Public.BaseName
-
-# Add HtmlAgilityPack type depending on PSVersion
 try {
     if (!([System.Management.Automation.PSTypeName]'HtmlAgilityPack.HtmlDocument').Type) {
         if ($PSVersionTable.PSEdition -eq "Desktop") {
@@ -25,3 +11,17 @@ try {
     $Err = $_
     throw $Err
 }
+
+$Public = @(Get-ChildItem -Path $PSScriptRoot\Public\*.ps1)
+$Private = @(Get-ChildItem -Path $PSScriptRoot\Private\*.ps1)
+$Classes = @(Get-ChildItem -Path $PSScriptRoot\Classes\*.ps1)
+
+foreach ($Module in ($Public + $Private + $Classes)) {
+    try {
+        . $Module.FullName
+    } catch {
+        Write-Error -Message "Failed to import function $($Module.FullName): $_"
+    }
+}
+
+Export-ModuleMember -Function $Public.BaseName

--- a/MSCatalog/Private/Invoke-CatalogRequest.ps1
+++ b/MSCatalog/Private/Invoke-CatalogRequest.ps1
@@ -1,0 +1,61 @@
+function Invoke-CatalogRequest {
+    [CmdletBinding()]
+    param (
+        [parameter(Mandatory = $true)]
+        [string] $Uri,
+
+        [Parameter(Mandatory = $false)]
+        [string] $Method = "Get",
+
+        [Parameter(Mandatory = $false)]
+        [string] $EventArgument,
+
+        [Parameter(Mandatory = $false)]
+        [string] $EventTarget,
+
+        [Parameter(Mandatory = $false)]
+        [string] $EventValidation,
+
+        [Parameter(Mandatory = $false)]
+        [string] $ViewState,
+
+        [Parameter(Mandatory = $false)]
+        [string] $ViewStateGenerator
+    )
+
+    try {
+        if ($Method -eq "Post") {
+            $ReqBody = @{
+                "__EVENTARGUMENT" = $EventArgument
+                "__EVENTTARGET" = $EventTarget
+                "__EVENTVALIDATION" = $EventValidation
+                "__VIEWSTATE" = $ViewState
+                "__VIEWSTATEGENERATOR" = $ViewStateGenerator
+            }
+        }
+        $Params = @{
+            Uri = [Uri]::EscapeUriString($Uri)
+            Method = $Method
+            Body = $ReqBody
+            ContentType = "application/x-www-form-urlencoded"
+            UseBasicParsing = $true
+            ErrorAction = "Stop"
+        }
+        $Results = Invoke-WebRequest @Params
+        $HtmlDoc = [HtmlAgilityPack.HtmlDocument]::new()
+        $HtmlDoc.LoadHtml($Results.RawContent.ToString())
+        $NoResults = $HtmlDoc.GetElementbyId("ctl00_catalogBody_noResultText")
+        if ($null -eq $NoResults) {
+            [MSCatalogResponse]::new($HtmlDoc)
+        } else {
+            throw "No results found."
+        }
+    } catch {
+        if ($_.Exception.Message -eq "No results found.") {
+            Write-Warning "$($NoResults.InnerText)$($Uri.Split("q=")[-1])"
+            break
+        } else {
+            throw $_
+        }
+    }
+}

--- a/MSCatalog/Private/Sort-CatalogResults.ps1
+++ b/MSCatalog/Private/Sort-CatalogResults.ps1
@@ -1,0 +1,76 @@
+function Sort-CatalogResults {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string] $Uri,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("Title", "Products", "Classification", "LastUpdated", "Size")]
+        [string] $SortBy,
+
+        [Parameter(Mandatory = $false)]
+        [switch] $Descending,
+
+        [Parameter(DontShow)]
+        [string] $EventArgument,
+
+        [Parameter(DontShow)]
+        [string] $EventValidation,
+
+        [Parameter(DontShow)]
+        [string] $ViewState,
+
+        [Parameter(DontShow)]
+        [string] $ViewStateGenerator
+    )
+
+    $EventTarget = switch ($SortBy) {
+        {$_ -eq "Title"} {'ctl00$catalogBody$updateMatches$ctl02$titleHeaderLink'}
+        {$_ -eq "Products"} {'ctl00$catalogBody$updateMatches$ctl02$productsHeaderLink'}
+        {$_ -eq "Classification"} {'ctl00$catalogBody$updateMatches$ctl02$classHeaderLink'}
+        {$_ -eq "LastUpdated"} {'ctl00$catalogBody$updateMatches$ctl02$dateHeaderLink'}
+        {$_ -eq "Size"} {'ctl00$catalogBody$updateMatches$ctl02$sizeHeaderLink'}
+    }
+
+    $Params = @{
+        Uri = $Uri
+        Method = "Post"
+        EventArgument = $EventArgument
+        EventTarget = $EventTarget
+        EventValidation = $EventValidation
+        ViewState = $ViewState
+        ViewStateGenerator = $ViewStateGenerator
+    }
+    $Res = Invoke-CatalogRequest @Params
+
+    # By default the LastUpdated field is sorted in descending order from the catalog website the first time you
+    # issue the sort POST request. All the other fields are sorted in ascending order first as you would expect.
+    # To ensure that this sort function is predictable we re-request the sorted request if the SortBy parameter is LastUpdated
+    # and the Descending parameter is $false in order to return the results sorted in ascending order which is what would
+    # be expected.
+    if (($SortBy -eq "LastUpdated") -and -not $Descending) {
+        $Params = @{
+            Uri = $Uri
+            Method = "Post"
+            EventArgument = $Res.EventArgument
+            EventTarget = $EventTarget
+            EventValidation = $Res.EventValidation
+            ViewState = $Res.ViewState
+            ViewStateGenerator = $Res.ViewStateGenerator
+        }
+        $Res = Invoke-CatalogRequest @Params
+    } elseif (($SortBy -ne "LastUpdated") -and $Descending) {
+        $Params = @{
+            Uri = $Uri
+            Method = "Post"
+            EventArgument = $Res.EventArgument
+            EventTarget = $EventTarget
+            EventValidation = $Res.EventValidation
+            ViewState = $Res.ViewState
+            ViewStateGenerator = $Res.ViewStateGenerator
+        }
+        $Res = Invoke-CatalogRequest @Params
+    }
+
+    $Res
+}

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ It is currently tested against the following images/PowerShell versions via AppV
 ## Get-MSCatalogUpdate
 
 This command is used to retrieve updates from the [https://www.catalog.update.microsoft.com](https://www.catalog.update.microsoft.com)
-website. By default it returns the first 25 items from the search.
+website. By default it returns the first 25 items from the search sorted by the LastUpdated field in descending order.
 
 ```powershell
 Get-MSCatalogUpdate -Search "Cumulative Update for Windows Server 2016 (1803)"
@@ -60,7 +60,19 @@ Title                                                                           
 2019-08 Cumulative Update for Windows Server 2016 (1803) for x64-based Systems (KB4512501)          Windows Server 2016 Security Updates 2019/08/09  919.3 MB
 ```
 
-However, if you would like to return all available results you can specify the `AllPages` parameter.
+The `SortBy` and `Descending` parameters allow you to manipulate the search results. For example:
+
+```powershell
+Get-MSCatalogUpdate -Search "Cumulative Update for Windows Server 2016 (1803)" -SortBy "Title" -Descending
+```
+
+The `Strict` parameter will return results which only contain the exact search term. For example:
+
+```powershell
+Get-MSCatalogUpdate -Search "Cumulative Update for Windows Server 2016 (1803)" -Strict
+```
+
+If you would like to return all available results you can specify the `AllPages` parameter.
 
 ```powershell
 Get-MSCatalogUpdate -Search "Cumulative Update for Windows Server 2016 (1803)" -AllPages


### PR DESCRIPTION
Following discussion in #6 it was decided that to improve performance, and provide the maximum flexibility, the `Get-MSCatalogUpdate` command would be refactored to implement a `SortBy` parameter. This parameter sorts the results by issuing POST requests to the [catalog.update.microsoft.com](catalog.update.microsoft.com) site. This performs much better than pulling all results using the `AllPages` parameter and then sorting using the native `Sort-Object` PowerShell command, which is currently the only way to sort the results.

As well as the `SortBy` parameter I have also improved the `Strict` parameter. Previously, when using the `Strict` parameter without the `AllPages` parameter, the first page of 25 results were returned from the [catalog.update.microsoft.com](catalog.update.microsoft.com) site and then we were filtering out any results which did not strictly match the search term. This was confusing to the end user as it could appear, incorrectly, that there were no more results to fetch (for example if there were only 4 strict matches in the first page of 25 results). In order to make this behave a bit more as expected, if you now issue the `Strict` parameter without the `AllPages` parameter the command will continue to request results from the [catalog.update.microsoft.com](catalog.update.microsoft.com) site and filter them by the strict search term until there are 25 results to display (unless there are fewer than 25 results in total).

I have also implemented classes for both the [catalog.update.microsoft.com](catalog.update.microsoft.com) site response object and this module's main MSCatalogUpdate object which enabled me to refactor the code to be more efficient and easier to read.