### PR TITLE
Bug fix: Exception in MSCatalogUpdate Class if item is larger than 2 GiB

### DIFF
--- a/MSCatalog/Classes/MSCatalogUpdate.Class.ps1
+++ b/MSCatalog/Classes/MSCatalogUpdate.Class.ps1
@@ -19,7 +19,7 @@ class MSCatalogUpdate {
         $this.LastUpdated = (Invoke-ParseDate -DateString $Cells[4].innerText.Trim())
         $this.Version = $Cells[5].innerText.Trim()
         $this.Size = $Cells[6].SelectNodes("span")[0].InnerText
-        $this.SizeInBytes = [Int] $Cells[6].SelectNodes("span")[1].InnerText 
+        $this.SizeInBytes = [Int64] $Cells[6].SelectNodes("span")[1].InnerText 
         $this.Guid = $Cells[7].SelectNodes("input")[0].Id
         $this.FileNames = if ($IncludeFileNames) {
             $Links = Get-UpdateLinks -Guid $Cells[7].SelectNodes("input")[0].Id


### PR DESCRIPTION
Fixed by changing the conversion type for $this.SizeInBytes to Int64