### PR TITLE
Suggestion: Substitute hash verification for signature verification

### DIFF
--- a/MSCatalog/Private/Invoke-DownloadFile.ps1
+++ b/MSCatalog/Private/Invoke-DownloadFile.ps1
@@ -27,7 +27,7 @@ function Invoke-DownloadFile {
 
         $Signature = (Get-AuthenticodeSignature $Path).Status
         if ($Signature -ne "Valid") {
-            throw "The hash of the downloaded file does not match the expected value."
+            throw "The signature of the downloaded file could not be validated."
         }
 
         Set-TempSecurityProtocol -ResetToDefault

--- a/MSCatalog/Private/Invoke-DownloadFile.ps1
+++ b/MSCatalog/Private/Invoke-DownloadFile.ps1
@@ -7,10 +7,10 @@ function Invoke-DownloadFile {
     )
     
     try {
-        # Check to see if file is already downloaded and the hash matches, if it does, we do not need to re-download
+        # Check to see if file is already downloaded and the signature is valid, if it is, we do not need to re-download
         if (Test-Path $Path) {
-            $Hash = Get-FileHash -Path $Path -Algorithm SHA1
-            if ($Path -match "$($Hash.Hash)\.msu$") {
+            $Signature = (Get-AuthenticodeSignature $Path).Status
+            if ($Signature -eq "Valid") {
                 return
             }
         }
@@ -25,8 +25,8 @@ function Invoke-DownloadFile {
             $WebClient.Dispose()
         }
 
-        $Hash = Get-FileHash -Path $Path -Algorithm SHA1
-        if ($Path -notmatch "$($Hash.Hash)\.msu$") {
+        $Signature = (Get-AuthenticodeSignature $Path).Status
+        if ($Signature -ne "Valid") {
             throw "The hash of the downloaded file does not match the expected value."
         }
 


### PR DESCRIPTION
Some older or more obscure updates on the Microsoft Update Catalog do not contain a valid SHA256 hash in their file name, thus always failing the downloader's hash verification every time, even when the download was completed successfully.

But since Microsoft signs basically every file that can be downloaded from the Catalog with a digital signature, they can easily be verified using Get-AuthenticodeSignature. And since signatures guarantee the integrity of a file as well, becoming invalid on corrupt or modified files, this can be a great substitute for the inconsistent hashing system.

If you want to test this out, you can try the update 74ec20c7-cfd5-4485-92c4-8b5fbf1d616f, which will fail the hash check but pass the signature check.

Hash check:
```
PS D:\_wsus4> Save-MSCatalogUpdate -Destination ".\" -Guid "74ec20c7-cfd5-4485-92c4-8b5fbf1d616f"
Id  FileName
--  --------
 0  writer_959b733a7c5a7bdbee9c2cfd1f81a954200f8637.cab
[...]
32  writer_a57bed3f9f6dcb1c62c5ccd4506e60066b0a705b.cab
Multiple files exist for this update. Enter the Id of the file to download or 'A' to download all files.: 0
The hash of the downloaded file does not match the expected value.
At D:\_wsus4\MSCatalog\MSCatalog\Private\Invoke-DownloadFile.ps1:30 char:13
+             throw "The hash of the downloaded file does not match the ...
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : OperationStopped: (The hash of the...expected value.:String) [], RuntimeException
    + FullyQualifiedErrorId : The hash of the downloaded file does not match the expected value.

PS D:\_wsus4>
```

Signature check:
```
PS D:\_wsus4> Save-MSCatalogUpdate -Destination ".\" -Guid "74ec20c7-cfd5-4485-92c4-8b5fbf1d616f"
Id  FileName
--  --------
 0  writer_ef61428ab6a31fcc84c4ea1f26b56c498eb2045a.cab
[...]
32  writer_30f319223e2b59ae491feaf4e54573e9bd68c1d7.cab
Multiple files exist for this update. Enter the Id of the file to download or 'A' to download all files.: 0
PS D:\_wsus4>
```